### PR TITLE
Backend/current plus 2 get all appointments

### DIFF
--- a/Backend/src/models/appointments.model.ts
+++ b/Backend/src/models/appointments.model.ts
@@ -8,16 +8,21 @@ async function findAllAppointments(
   searchTerm: string
 ) {
   try {
-    const EODtime = new Date(searchTerm.substring(0, 10) + "T23:59:59.999Z");
     const overFetchAmount = take * 2;
     const skipAmount = page * take;
+
+    const searchDate = new Date(searchTerm);
+    const EODtime = new Date(searchDate);
+    EODtime.setMonth(EODtime.getMonth() + 2);
+    EODtime.setHours(23, 59, 59, 999);
+
     const appointments = await prisma.appointment.findMany({
       skip: skipAmount,
       take: overFetchAmount,
       where: {
         arrivalDateTime: {
-          gte: new Date(searchTerm),
-          lt: new Date(EODtime),
+          gte: searchDate,
+          lt: EODtime,
         },
       },
     });


### PR DESCRIPTION
A change to findAllAppointments was requested so it would look at the current month plus 2 months ahead.

Change was implemented but keep in mind that following the "2022-03-25T10:51:00.000Z" format means we only look from this day/month + 2. Lmk if changes need to be made if the scope of the change was to include day 1 of month x to FINAL day of month x + 2.

Implementation was tested in postman. Was tested with 5 appointments with incrementing months and upon request, 3 appointments were returned in accordance with implementation request.